### PR TITLE
CallHome OSGI bundle for Carbon kernel 5.2.x products

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,9 @@
                             !org.wso2.callhome.*
                         </Export-Package>
                         <Import-Package>
-                            org.osgi.framework; version="[1.7,1.8)",
-                            org.wso2.carbon.core; version="[4.4.0,4.5.0)",
-                            org.wso2.carbon.utils; version="[4.4.0,4.5.0)",
+                            org.osgi.framework; version="[1.9,2.0)",
+                            org.wso2.carbon.core; version="[4.5.0,4.6.0)",
+                            org.wso2.carbon.utils; version="[4.5.0,4.6.0)",
                             org.apache.commons.logging,
                         </Import-Package>
                         <Embed-Dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,19 +39,38 @@
         <dependency>
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.osgi</artifactId>
-            <version>3.14.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.core</artifactId>
-            <version>4.5.2</version>
+            <version>${org.eclipse.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.23</version>
+            <version>${org.yaml.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+            <version>${org.wso2.eclipse.osgi.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+            <version>${org.wso2.eclipse.osgi.services.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+            <version>${org.wso2.carbon.version}</version>
         </dependency>
     </dependencies>
+    <properties>
+        <org.eclipse.platform.version>3.14.0</org.eclipse.platform.version>
+        <org.yaml.version>1.23</org.yaml.version>
+        <org.wso2.eclipse.osgi.version>3.11.0.v20160603-1336</org.wso2.eclipse.osgi.version>
+        <org.wso2.eclipse.osgi.services.version>3.5.100.v20160504-1419</org.wso2.eclipse.osgi.services.version>
+        <org.wso2.carbon.version>5.2.0</org.wso2.carbon.version>
+    </properties>
     <build>
         <plugins>
             <plugin>
@@ -71,9 +90,9 @@
                             !org.wso2.callhome.*
                         </Export-Package>
                         <Import-Package>
-                            org.osgi.framework; version="[1.9,2.0)",
-                            org.wso2.carbon.core; version="[4.5.0,4.6.0)",
-                            org.wso2.carbon.utils; version="[4.5.0,4.6.0)",
+                            org.slf4j.*,
+                            org.osgi.framework; version="[1.8.0, 2.0.0)",
+                            org.wso2.carbon.kernel; version="[5.2.0, 6.0.0)",
                             org.apache.commons.logging,
                         </Import-Package>
                         <Embed-Dependency>

--- a/src/main/java/org/wso2/callhome/internal/CallHomeComponent.java
+++ b/src/main/java/org/wso2/callhome/internal/CallHomeComponent.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.callhome.internal;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.callhome.utils.MessageFormatter;
+import org.wso2.carbon.kernel.CarbonServerInfo;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * This service component creates a CallHome service.
+ *
+ * @since 1.0.2
+ */
+@Component(
+        name = "org.wso2.callhome.internal.CallHomeComponent",
+        immediate = true
+)
+public class CallHomeComponent {
+
+    private static final Logger logger = LoggerFactory.getLogger(CallHome.class);
+    private static final int CALL_HOME_TIMEOUT_SECONDS = 180;
+    private static final int LINE_LENGTH = 80;
+
+    @Activate
+    public void activate() {
+
+        Thread callHomeComponentThread = new Thread(() -> {
+            logger.debug("Activating CallHome component");
+            Future<String> callHomeResponse = DataHolder.getInstance().getResponse();
+            if (callHomeResponse != null) {
+                try {
+                    String response = callHomeResponse.get(CALL_HOME_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                    if (!response.isEmpty()) {
+                        String formattedMessage = MessageFormatter.formatMessage(response, LINE_LENGTH);
+                        logger.info(formattedMessage);
+                    }
+                } catch (InterruptedException e) {
+                    logger.debug("CallHome is interrupted", e);
+                } catch (ExecutionException e) {
+                    logger.debug("CallHome execution failure", e);
+                } catch (TimeoutException e) {
+                    logger.debug("CallHome did not complete in expected time", e);
+                }
+            } else {
+                logger.debug("CallHome response is not available");
+            }
+        });
+        callHomeComponentThread.setDaemon(true);
+        callHomeComponentThread.setName("callHomeComponentThread");
+        callHomeComponentThread.start();
+    }
+
+    @Deactivate
+    public void deactivate() {
+
+        logger.debug("Deactivating CallHome component");
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.kernel",
+            service = CarbonServerInfo.class,
+            cardinality = ReferenceCardinality.AT_LEAST_ONE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterCallHomeService"
+    )
+    protected void registerCallHomeService(CarbonServerInfo carbonServerInfo) {
+
+        logger.debug("CallHome service registered");
+    }
+
+    protected void unregisterCallHomeService(CarbonServerInfo carbonServerInfo) {
+
+        logger.debug("CallHome service unregistered");
+    }
+}

--- a/src/main/java/org/wso2/callhome/internal/DataHolder.java
+++ b/src/main/java/org/wso2/callhome/internal/DataHolder.java
@@ -17,32 +17,34 @@
  */
 package org.wso2.callhome.internal;
 
-import org.osgi.framework.BundleActivator;
-import org.osgi.framework.BundleContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.concurrent.Future;
 
 /**
- * The CallHomeActivator class executes {@link CallHome}.
+ * CallHome DataHolder
  *
  * @since 1.0.2
  */
-public class CallHomeActivator implements BundleActivator {
+class DataHolder {
 
-    private static final Logger logger = LoggerFactory.getLogger(CallHomeActivator.class);
+    private static DataHolder instance = new DataHolder();
+    private Future<String> response;
 
-    @Override
-    public void start(BundleContext bundleContext) {
+    private DataHolder() {
 
-        logger.debug("Activating CallHome agent");
-
-        CallHome callHome = new CallHome();
-        callHome.execute();
     }
 
-    @Override
-    public void stop(BundleContext bundleContext) {
+    static DataHolder getInstance() {
 
-        logger.debug("Deactivating CallHome agent");
+        return instance;
+    }
+
+    Future<String> getResponse() {
+
+        return response;
+    }
+
+    void setResponse(Future<String> response) {
+
+        this.response = response;
     }
 }


### PR DESCRIPTION
## Purpose
> Add CallHome OSGI bundle as a declarative service for kernel 5.2.x products

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes