### PR TITLE
Fix profile based carbon home issue

### DIFF
--- a/src/main/java/org/wso2/callhome/internal/CallHome.java
+++ b/src/main/java/org/wso2/callhome/internal/CallHome.java
@@ -123,6 +123,11 @@ class CallHome implements Callable<String>, ServerStartupObserver {
 
         if (carbonProductHome == null) {
             carbonProductHome = CarbonUtils.getCarbonHome();
+            Path updatesDirPath = Paths.get(carbonProductHome, "updates");
+            if (!Files.isDirectory(updatesDirPath)) {
+                File file = new File(carbonProductHome);
+                carbonProductHome = String.valueOf(file.getParentFile().getParentFile());
+            }
         }
         return carbonProductHome;
     }


### PR DESCRIPTION
## Purpose
> Fix product home path when running EI and Analytics profiles

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

