### PR TITLE
Add method to retrieve trial-subscription-id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.wso2.carbon.callhome</groupId>
     <artifactId>callhome</artifactId>
     <name>Call Home Client</name>
-    <version>4.5.x_1.0.2-SNAPSHOT</version>
+    <version>4.4.x_1.0.4-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <modelVersion>4.0.0</modelVersion>
 

--- a/src/main/java/org/wso2/callhome/utils/ExtractedInfo.java
+++ b/src/main/java/org/wso2/callhome/utils/ExtractedInfo.java
@@ -28,6 +28,7 @@ public class ExtractedInfo {
     private String productName;
     private String productVersion;
     private String operatingSystem;
+    private String trialSubscriptionId;
     private long updateLevel;
 
     public String getChannel() {
@@ -68,6 +69,16 @@ public class ExtractedInfo {
     public void setOperatingSystem(String operatingSystem) {
 
         this.operatingSystem = operatingSystem;
+    }
+
+    public String getTrialSubscriptionId() {
+
+        return trialSubscriptionId;
+    }
+
+    public void setTrialSubscriptionId(String trialSubscriptionId) {
+
+        this.trialSubscriptionId = trialSubscriptionId;
     }
 
     public long getUpdateLevel() {


### PR DESCRIPTION
## Purpose
> Add a method to get the trial subscription information

## Goals
> Validate the trial subscription id.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK versions - Oracle JDK 1.8
> Operating systems - Ubuntu 18.04
