### PR TITLE
Add method to retrieve trial-subscription-id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.wso2.carbon.callhome</groupId>
     <artifactId>callhome</artifactId>
     <name>Call Home Client</name>
-    <version>6.x.x_1.0.2-SNAPSHOT</version>
+    <version>5.x.x_1.0.4-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <modelVersion>4.0.0</modelVersion>
 

--- a/src/main/java/org/wso2/callhome/internal/CallHome.java
+++ b/src/main/java/org/wso2/callhome/internal/CallHome.java
@@ -115,6 +115,7 @@ public class CallHome implements Callable<String> {
 
             String productName = extractProductName(productNameAndVersion);
             String productVersion = extractProductVersion(productNameAndVersion);
+            String trialSubscriptionId = getTrialSubscriptionId();
 
             ExtractedInfo extractedInfo = new ExtractedInfo();
             extractedInfo.setChannel(channel);
@@ -122,6 +123,7 @@ public class CallHome implements Callable<String> {
             extractedInfo.setProductVersion(productVersion);
             extractedInfo.setOperatingSystem(operatingSystem);
             extractedInfo.setUpdateLevel(updateLevel);
+            extractedInfo.setTrialSubscriptionId(trialSubscriptionId);
 
             return retrieveUpdateInfoFromServer(extractedInfo);
         } catch (CallHomeException e) {
@@ -305,6 +307,7 @@ public class CallHome implements Callable<String> {
         String productVersion = extractedInfo.getProductVersion();
         String operatingSystem = extractedInfo.getOperatingSystem();
         String channel = extractedInfo.getChannel();
+        String trialSubscriptionId = extractedInfo.getTrialSubscriptionId();
         long updateLevel = extractedInfo.getUpdateLevel();
         try {
             return new URL(CALL_HOME_ENDPOINT +
@@ -312,7 +315,8 @@ public class CallHome implements Callable<String> {
                     "&product-version=" + URLEncoder.encode(productVersion, "UTF-8") +
                     "&operating-system=" + URLEncoder.encode(operatingSystem, "UTF-8") +
                     "&updates-level=" + URLEncoder.encode(String.valueOf(updateLevel), "UTF-8") +
-                    "&channel=" + URLEncoder.encode(channel, "UTF-8"));
+                    "&channel=" + URLEncoder.encode(channel, "UTF-8") +
+                    "&trial-subscription-id=" + URLEncoder.encode(trialSubscriptionId, "UTF-8"));
         } catch (MalformedURLException e) {
             log.debug("Error while creating URL for the CallHome endpoint " + e.getMessage());
             throw new CallHomeException("Error while creating URL for the CallHome endpoint", e);
@@ -448,4 +452,26 @@ public class CallHome implements Callable<String> {
         callHomeComponentThread.setName("callHomeComponentThread");
         callHomeComponentThread.start();
     }
+
+    /**
+     * This method returns the trial subscription id.
+     *
+     * @return Trial subscription id
+     * @throws CallHomeException If unable to read the content of the trialSubscriptionId.txt
+     */
+    private String getTrialSubscriptionId() throws CallHomeException {
+
+        Path trialSubscriptionIdPath = Paths.get(getProductHome(), "updates", "trialSubscriptionId.txt");
+        byte[] trialSubscriptionId = new byte[0];
+        if (Files.exists(trialSubscriptionIdPath)) {
+            try {
+                trialSubscriptionId = Files.readAllBytes(trialSubscriptionIdPath);
+            } catch (IOException e) {
+                log.debug("Unable to read the trialSubscriptionId.txt content");
+                throw new CallHomeException("Unable to read the trialSubscriptionId.txt content", e);
+            }
+        }
+        return new String(trialSubscriptionId, StandardCharsets.UTF_8).trim();
+    }
+
 }

--- a/src/main/java/org/wso2/callhome/utils/ExtractedInfo.java
+++ b/src/main/java/org/wso2/callhome/utils/ExtractedInfo.java
@@ -28,6 +28,7 @@ public class ExtractedInfo {
     private String productName;
     private String productVersion;
     private String operatingSystem;
+    private String trialSubscriptionId;
     private long updateLevel;
 
     public String getChannel() {
@@ -68,6 +69,16 @@ public class ExtractedInfo {
     public void setOperatingSystem(String operatingSystem) {
 
         this.operatingSystem = operatingSystem;
+    }
+
+    public String getTrialSubscriptionId() {
+
+        return trialSubscriptionId;
+    }
+
+    public void setTrialSubscriptionId(String trialSubscriptionId) {
+
+        this.trialSubscriptionId = trialSubscriptionId;
     }
 
     public long getUpdateLevel() {


### PR DESCRIPTION
## Purpose
> Add a method to get the trial subscription information

## Goals
> Validate the trial subscription id.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK versions - Oracle JDK 1.8
> Operating systems - Ubuntu 18.04
