### PR TITLE
Remove warning message when unable to retrieve number of updates

### DIFF
--- a/src/main/java/org/wso2/callhome/CallHomeExecutor.java
+++ b/src/main/java/org/wso2/callhome/CallHomeExecutor.java
@@ -58,8 +58,10 @@ public class CallHomeExecutor {
 
         Thread callHomeThread = new Thread(() -> {
             String message = getMessage();
-            String formattedMessage = MessageFormatter.formatMessage(message, LINE_LENGTH);
-            log.info(formattedMessage);
+            if (!message.isEmpty()) {
+                String formattedMessage = MessageFormatter.formatMessage(message, LINE_LENGTH);
+                log.info(formattedMessage);
+            }
         });
         callHomeThread.setDaemon(true);
         callHomeThread.setName("callHomeThread");

--- a/src/main/java/org/wso2/callhome/core/CallHome.java
+++ b/src/main/java/org/wso2/callhome/core/CallHome.java
@@ -97,8 +97,7 @@ public class CallHome implements Callable<String> {
 
             return retrieveUpdateInfoFromServer(callHomeInfo);
         } catch (CallHomeException e) {
-            log.warn("Failed to get the number of updates available.");
-            log.debug(e.toString());
+            log.debug("Failed to get the number of updates available." + e.toString());
         }
         return "";
     }


### PR DESCRIPTION
## Purpose
> Remove warning log if unable to get the number of updates available.
> Fix message formatter issue when the message size is 9. 

## Test environment
> JDK versions - 1.8.0
> Operating systems - Ubuntu 18.04