### PR TITLE
Add configuration to disable the callhome check

### DIFF
--- a/src/main/java/org/wso2/callhome/CallHomeExecutor.java
+++ b/src/main/java/org/wso2/callhome/CallHomeExecutor.java
@@ -39,6 +39,7 @@ public class CallHomeExecutor {
     private static final Log log = LogFactory.getLog(CallHomeExecutor.class);
     private static final int CALL_HOME_TIMEOUT_SECONDS = 180;
     private static final int LINE_LENGTH = 80;
+    public static final String CARBON_AUTO_UPDATE_CHECK = "carbon.auto.update.check";
 
     /**
      * This method is used to execute the CallHome service.
@@ -47,8 +48,10 @@ public class CallHomeExecutor {
      */
     public static void execute(CallHomeInfo callHomeInfo) {
 
-        CallHome callHome = new CallHome(callHomeInfo);
-        callHome.execute();
+        if (!System.getProperty(CARBON_AUTO_UPDATE_CHECK).equals("false")) {
+            CallHome callHome = new CallHome(callHomeInfo);
+            callHome.execute();
+        }
     }
 
     /**

--- a/src/main/java/org/wso2/callhome/CallHomeExecutor.java
+++ b/src/main/java/org/wso2/callhome/CallHomeExecutor.java
@@ -48,7 +48,8 @@ public class CallHomeExecutor {
      */
     public static void execute(CallHomeInfo callHomeInfo) {
 
-        if (!System.getProperty(CARBON_AUTO_UPDATE_CHECK).equals("false")) {
+        if (!(System.getProperty(CARBON_AUTO_UPDATE_CHECK) == null) ||
+                !System.getProperty(CARBON_AUTO_UPDATE_CHECK).equals("false")) {
             CallHome callHome = new CallHome(callHomeInfo);
             callHome.execute();
         }

--- a/src/main/java/org/wso2/callhome/CallHomeExecutor.java
+++ b/src/main/java/org/wso2/callhome/CallHomeExecutor.java
@@ -48,7 +48,7 @@ public class CallHomeExecutor {
      */
     public static void execute(CallHomeInfo callHomeInfo) {
 
-        if (!(System.getProperty(CARBON_AUTO_UPDATE_CHECK) == null) ||
+        if ((System.getProperty(CARBON_AUTO_UPDATE_CHECK) == null) ||
                 !System.getProperty(CARBON_AUTO_UPDATE_CHECK).equals("false")) {
             CallHome callHome = new CallHome(callHomeInfo);
             callHome.execute();


### PR DESCRIPTION
## Purpose
> This configuration would disable the callhome check towards the updates servers.

## Goals
> Provide users to disable the callhome feature if necessary.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> List all JDK versions - Oracle JDK 1.8
> Oerating systems - Ubuntu 18.04