### PR TITLE
Bumping the callhome core version to reflect Gson 2.9.0 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <org.eclipse.platform>3.14.0</org.eclipse.platform>
         <org.wso2.carbon.core>4.5.2</org.wso2.carbon.core>
-        <org.wso2.carbon.callhome.core>1.0.11</org.wso2.carbon.callhome.core>
+        <org.wso2.carbon.callhome.core>1.0.12</org.wso2.carbon.callhome.core>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Purpose
Bumping the callhome core version to reflect Gson 2.9.0 upgrade done in [1].

## Related PRs
- https://github.com/wso2/call-home/pull/60