### PR TITLE
Changing the gson version to 2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <org.apache.httpcomponents.httpclient>4.5.13</org.apache.httpcomponents.httpclient>
         <org.apache.httpcomponents.httpcore>4.4.13</org.apache.httpcomponents.httpcore>
         <org.yaml.snakeyaml>1.26</org.yaml.snakeyaml>
-        <com.google.code.gson.gson>2.9.0</com.google.code.gson.gson>
+        <com.google.code.gson.gson>2.8.9</com.google.code.gson.gson>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Purpose
The gson 2.9.0 required to update the maven bundle version to a newer one in the call home client POM file due to [1]. But, changing it like that resulted in another problem, which is, that the call home jar did not get activated in the pack. Hence, using the gson 2.8.9 won't have any problems like this.


[1] https://stackoverflow.com/questions/53676071/maven-clean-command-java-util-collections-unmodifiablerandomaccesslist-to-prope