### PR TITLE
[1.x.x_4.5.x] Bumping the call home core version and revert the maven bundle plugin version to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <org.eclipse.platform>3.14.0</org.eclipse.platform>
         <org.wso2.carbon.core>4.5.2</org.wso2.carbon.core>
-        <org.wso2.carbon.callhome.core>1.0.12</org.wso2.carbon.callhome.core>
+        <org.wso2.carbon.callhome.core>1.0.13</org.wso2.carbon.callhome.core>
     </properties>
 
     <dependencies>
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.2.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
## Purpose
The gson 2.9.0 required updating the maven bundle version to a newer one in the POM file due to [1]. But, changing it like that resulted in another problem, which is, that the call home jar did not get activated in the pack. So the callhome 1.0.13 will have the gson 2.8.9. Hence, using the gson 2.8.9 won't have any problems like this.

[1] https://stackoverflow.com/questions/53676071/maven-clean-command-java-util-collections-unmodifiablerandomaccesslist-to-prope