### PR TITLE
Change carbon core version in call-home client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <org.wso2.eclipse.osgi.services.version>3.5.100.v20160504-1419</org.wso2.eclipse.osgi.services.version>
         <org.wso2.carbon.version>5.2.0</org.wso2.carbon.version>
         <carbon.config.version>2.1.16</carbon.config.version>
-        <org.wso2.carbon.callhome.core>1.0.10</org.wso2.carbon.callhome.core>
+        <org.wso2.carbon.callhome.core>1.0.13</org.wso2.carbon.callhome.core>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
## Purpose
HttpClient is packed in call-home jar from call-home core. httpClient version is already upgraded to 4.5.13 in call home core v1.0.13. Therefore here we have to upgrade the call-home core version in call home jar. 
