### PR TITLE
Update callhome core version with the Gson dependency upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <org.eclipse.platform>3.14.0</org.eclipse.platform>
         <org.wso2.carbon.core>4.5.2</org.wso2.carbon.core>
-        <org.wso2.carbon.callhome.core>1.0.14</org.wso2.carbon.callhome.core>
+        <org.wso2.carbon.callhome.core>1.0.15</org.wso2.carbon.callhome.core>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Purpose
> Public fix for security advisory WSO2-2022-2198.
Relates to https://github.com/wso2/call-home/pull/72 
