### PR TITLE
Downgrade mvn bundle plugin version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <properties>
         <org.eclipse.platform>3.14.0</org.eclipse.platform>
         <org.wso2.carbon.core>4.5.2</org.wso2.carbon.core>
-        <org.wso2.carbon.callhome.core>1.0.16</org.wso2.carbon.callhome.core>
+        <org.wso2.carbon.callhome.core>1.0.17</org.wso2.carbon.callhome.core>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.2.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
## Purpose
- mvn bundle plugin 3.5  makes the bundle not activated. 
- Downgrade the bundle plugin version to fix that.
-  Change is introduced with this PR : https://github.com/wso2/call-home/pull/79 , this change was done after upgrading the snake yaml version, to fix the build failure due to https://issues.apache.org/jira/browse/FELIX-5698
- With the mvn bundle plugin version , the bundle is not properly work and there is a null pointer exception from the osgi service.

- To fix the issue after upgrading the snake yml version -->  used the snake yml orbit jar. (https://github.com/wso2/orbit/tree/master/snakeyaml/2.0.0.wso2v1) -->https://github.com/wso2/call-home/pull/82
- With that no need to upgrade the mvn plugin version which introduces issues.


## Merge after
https://github.com/wso2/call-home/pull/82